### PR TITLE
Feat: heavily sandbox scripts with Systemd

### DIFF
--- a/nginx-create-session-ticket-keys.service
+++ b/nginx-create-session-ticket-keys.service
@@ -8,5 +8,32 @@ User=root
 Group=root
 ExecStart=/usr/local/bin/nginx-create-session-ticket-keys
 
-[Install]
-WantedBy=multi-user.target
+PrivateNetwork=true
+IPAddressDeny=any
+
+# this service mounts a ramfs, so it needs some special privs
+
+RestrictAddressFamilies=none
+CapabilityBoundingSet=CAP_SYS_ADMIN
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+RemoveIPC=true
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+
+
+DevicePolicy=strict
+DeviceAllow=/dev/urandom r
+DeviceAllow=/dev/null w
+DeviceAllow=/dev/stdin r
+
+ProtectClock=true
+
+# filesystem restrictions
+UMask=0077
+
+SystemCallArchitectures=native
+SystemCallFilter=@system-service @mount
+SystemCallFilter=~@clock @debug @module @reboot @swap @resources @cpu-emulation @obsolete @raw-io @obsolete @keyring @privileged

--- a/nginx-rotate-session-ticket-keys
+++ b/nginx-rotate-session-ticket-keys
@@ -12,4 +12,7 @@ rsync -It 4.key 3.key
 openssl rand -out new.key 80
 rsync -It new.key 4.key
 rm new.key
-nginx -s reload
+
+if [ "$#" -gt 0 ]; then
+	[ "$1" = '-r' ] && nginx -s reload
+fi

--- a/nginx-rotate-session-ticket-keys.service
+++ b/nginx-rotate-session-ticket-keys.service
@@ -7,3 +7,49 @@ Type=oneshot
 User=root
 Group=root
 ExecStart=/usr/local/bin/nginx-rotate-session-ticket-keys
+ExecStartPost=systemctl reload nginx.service
+
+PrivateDevices=true
+PrivateIPC=true
+PrivateNetwork=true
+PrivateTmp=true
+PrivateUsers=true
+
+# limit privs
+CapabilityBoundingSet=
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+RemoveIPC=true
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+
+# required to run systemctl in ExecStartPost
+RestrictAddressFamilies=AF_UNIX
+
+IPAddressDeny=any
+
+DevicePolicy=strict
+DeviceAllow=/dev/urandom r
+DeviceAllow=/dev/null w
+DeviceAllow=/dev/stdin r
+
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=yes
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=invisible
+ProcSubset=pid
+
+# filesystem restrictions
+ProtectSystem=strict
+ReadWritePaths=/etc/nginx/session-ticket-keys
+UMask=0077
+
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@clock @debug @module @mount @reboot @swap @resources @cpu-emulation @obsolete @raw-io @obsolete @keyring @privileged


### PR DESCRIPTION
Restrict all unnecessary privileges; "systemd-analyze security" now
reports an exposure level of "0.5 SAFE".

Make nginx-rotate-session-ticket-keys skip reloading nginx by default,
as that is functionality it cannot perform while sandboxed. Delegate
this to the service manager. The example Systemd unit now reloads the
nginx configs itself using "systemctl reload"; this should be equivalent
to running "nginx -s reload" as the default nginx unit files reload
nginx by sending a HUP signal to its main PID.

Existing users who use the Systemd service as-is should be able to
update without any changes. Users who would rather bundle
nginx-reloading functionality into the nginx-rotate-session-ticket-keys
script can still do so with the cmdline flag "-r".