### PR TITLE
Replace rsync with cp

### DIFF
--- a/nginx-rotate-session-ticket-keys
+++ b/nginx-rotate-session-ticket-keys
@@ -6,10 +6,10 @@ umask 077
 
 cd /etc/nginx/session-ticket-keys
 
-rsync -It 2.key 1.key
-rsync -It 3.key 2.key
-rsync -It 4.key 3.key
+cp -p 2.key 1.key
+cp -p 3.key 2.key
+cp -p 4.key 3.key
 openssl rand -out new.key 80
-rsync -It new.key 4.key
+cp -p new.key 4.key
 rm new.key
 nginx -s reload


### PR DESCRIPTION
`cp -p` covers the functionality of `rsync -It`:
- `cp` doesn't skip files based on mtimes, covering `-I`
- POSIX cp's `-p` flag preserves metadata inc. modification and
  last-accessed timestamps

This eliminates the large dependency on rsync; now, the only dependency
is openssl (or equivalent).