### PR TITLE
Make scripts portable

### DIFF
--- a/nginx-create-session-ticket-keys
+++ b/nginx-create-session-ticket-keys
@@ -1,15 +1,12 @@
-#!/bin/bash
+#!/bin/sh
 
-set -o errexit -o nounset -o pipefail
+set -o errexit -o nounset
 
 umask 077
 
 mkdir -p /etc/nginx/session-ticket-keys
 mount -t ramfs -o mode=700 ramfs /etc/nginx/session-ticket-keys
 
-cd /etc/nginx/session-ticket-keys
-
-openssl rand -out 1.key 80
-openssl rand -out 2.key 80
-openssl rand -out 3.key 80
-openssl rand -out 4.key 80
+for i in 1 2 3 4; do
+	dd ibs=1 obs=1 count='80' 2>/dev/null </dev/urandom >"/etc/nginx/session-ticket-keys/$i.key"
+done

--- a/nginx-create-session-ticket-keys
+++ b/nginx-create-session-ticket-keys
@@ -8,5 +8,7 @@ mkdir -p /etc/nginx/session-ticket-keys
 mount -t ramfs -o mode=700 ramfs /etc/nginx/session-ticket-keys
 
 for i in 1 2 3 4; do
-	dd ibs=1 obs=1 count='80' 2>/dev/null </dev/urandom >"/etc/nginx/session-ticket-keys/$i.key"
+	# use /dev/random instead of urandom in case urandom hasn't been seeded
+	# on modern kernels it is good enough for our purposes
+	dd ibs=1 obs=1 count='80' 2>/dev/null </dev/random >"/etc/nginx/session-ticket-keys/$i.key"
 done

--- a/nginx-create-session-ticket-keys.service
+++ b/nginx-create-session-ticket-keys.service
@@ -8,5 +8,32 @@ User=root
 Group=root
 ExecStart=/usr/local/bin/nginx-create-session-ticket-keys
 
-[Install]
-WantedBy=multi-user.target
+PrivateNetwork=true
+IPAddressDeny=any
+
+# this service mounts a ramfs, so it needs some special privs
+
+RestrictAddressFamilies=none
+CapabilityBoundingSet=CAP_SYS_ADMIN
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+RemoveIPC=true
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+
+
+DevicePolicy=strict
+DeviceAllow=/dev/urandom r
+DeviceAllow=/dev/null w
+DeviceAllow=/dev/stdin r
+
+ProtectClock=true
+
+# filesystem restrictions
+UMask=0077
+
+SystemCallArchitectures=native
+SystemCallFilter=@system-service @mount
+SystemCallFilter=~@clock @debug @module @reboot @swap @resources @cpu-emulation @obsolete @raw-io @obsolete @keyring @privileged

--- a/nginx-create-session-ticket-keys.service
+++ b/nginx-create-session-ticket-keys.service
@@ -25,7 +25,7 @@ RestrictSUIDSGID=true
 
 
 DevicePolicy=strict
-DeviceAllow=/dev/urandom r
+DeviceAllow=/dev/random r
 DeviceAllow=/dev/null w
 DeviceAllow=/dev/stdin r
 

--- a/nginx-rotate-session-ticket-keys
+++ b/nginx-rotate-session-ticket-keys
@@ -6,13 +6,18 @@ umask 077
 
 cd /etc/nginx/session-ticket-keys
 
-for i in 1 2 3; do
-	cp -p "$((i + 1)).key" "$i.key"
-done
-
 # use /dev/random instead of urandom in case urandom hasn't been seeded
 # on modern kernels it is good enough for our purposes
-dd ibs=1 obs=1 count='80' 2>/dev/null </dev/random >4.key
+dd ibs=1 obs=1 count='80' 2>/dev/null </dev/random >5.key
+
+for i in 1 2 3 4; do
+	# rotate keys but preserve timestamps
+	# use a tmpfile to ensure that operations are atomic; there's never a missing key
+	cp -p "$((i + 1)).key" tmp.key
+	mv tmp.key "$i.key"
+done
+
+rm 5.key
 
 if [ "$#" -gt 0 ]; then
 	[ "$1" = '-r' ] && nginx -s reload

--- a/nginx-rotate-session-ticket-keys
+++ b/nginx-rotate-session-ticket-keys
@@ -12,4 +12,7 @@ rsync -It 4.key 3.key
 openssl rand -out new.key 80
 rsync -It new.key 4.key
 rm new.key
-nginx -s reload
+
+if [ "$#" -gt 0 ]; then
+	[ "$1" = '-r' ] && nginx -s reload
+fi

--- a/nginx-rotate-session-ticket-keys
+++ b/nginx-rotate-session-ticket-keys
@@ -10,7 +10,9 @@ for i in 1 2 3; do
 	cp -p "$((i + 1)).key" "$i.key"
 done
 
-dd ibs=1 obs=1 count='80' 2>/dev/null </dev/urandom >4.key
+# use /dev/random instead of urandom in case urandom hasn't been seeded
+# on modern kernels it is good enough for our purposes
+dd ibs=1 obs=1 count='80' 2>/dev/null </dev/random >4.key
 
 if [ "$#" -gt 0 ]; then
 	[ "$1" = '-r' ] && nginx -s reload

--- a/nginx-rotate-session-ticket-keys
+++ b/nginx-rotate-session-ticket-keys
@@ -1,17 +1,16 @@
-#!/bin/bash
+#!/bin/sh
 
-set -o errexit -o nounset -o pipefail
+set -o errexit -o nounset
 
 umask 077
 
 cd /etc/nginx/session-ticket-keys
 
-rsync -It 2.key 1.key
-rsync -It 3.key 2.key
-rsync -It 4.key 3.key
-openssl rand -out new.key 80
-rsync -It new.key 4.key
-rm new.key
+for i in 1 2 3; do
+	cp -p "$((i + 1)).key" "$i.key"
+done
+
+dd ibs=1 obs=1 count='80' 2>/dev/null </dev/urandom >4.key
 
 if [ "$#" -gt 0 ]; then
 	[ "$1" = '-r' ] && nginx -s reload

--- a/nginx-rotate-session-ticket-keys.service
+++ b/nginx-rotate-session-ticket-keys.service
@@ -31,7 +31,7 @@ RestrictAddressFamilies=AF_UNIX
 IPAddressDeny=any
 
 DevicePolicy=strict
-DeviceAllow=/dev/urandom r
+DeviceAllow=/dev/random r
 DeviceAllow=/dev/null w
 DeviceAllow=/dev/stdin r
 

--- a/nginx-rotate-session-ticket-keys.service
+++ b/nginx-rotate-session-ticket-keys.service
@@ -7,3 +7,49 @@ Type=oneshot
 User=root
 Group=root
 ExecStart=/usr/local/bin/nginx-rotate-session-ticket-keys
+ExecStartPost=systemctl reload nginx.service
+
+PrivateDevices=true
+PrivateIPC=true
+PrivateNetwork=true
+PrivateTmp=true
+PrivateUsers=true
+
+# limit privs
+CapabilityBoundingSet=
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+RemoveIPC=true
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+
+# required to run systemctl in ExecStartPost
+RestrictAddressFamilies=AF_UNIX
+
+IPAddressDeny=any
+
+DevicePolicy=strict
+DeviceAllow=/dev/urandom r
+DeviceAllow=/dev/null w
+DeviceAllow=/dev/stdin r
+
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=yes
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=invisible
+ProcSubset=pid
+
+# filesystem restrictions
+ProtectSystem=strict
+ReadWritePaths=/etc/nginx/session-ticket-keys
+UMask=0077
+
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@clock @debug @module @mount @reboot @swap @resources @cpu-emulation @obsolete @raw-io @obsolete @keyring @privileged


### PR DESCRIPTION
Removed dependencies (bash, openssl, rsync); the scripts are now
dependency-free, except for a POSIX userspace and /dev/urandom. All
behavior is the same as before.

1. Replace "rsync -It" with "cp -p".
2. Use "dd </dev/urandom" instead of openssl to support systems without
   the openssl CLI tool.
3. Remove bashisms to support POSIX sh.

The third point required removing the "pipefail" setting, which is
useless for these scripts since they don't pipe data between processes.

nginx-rotate-session-ticket-keys should now work on many more systems
than before, including Alpine and HardenedBSD servers.