### PR TITLE
Delegate ramfs provisioning to systemd

### DIFF
--- a/etc-nginx-session_ticket_keys.automount
+++ b/etc-nginx-session_ticket_keys.automount
@@ -1,0 +1,8 @@
+[Unit]
+Description=session ticket keys automount
+
+[Automount]
+Where=/etc/nginx/session_ticket_keys
+
+[Install]
+WantedBy=multi-user.target

--- a/etc-nginx-session_ticket_keys.mount
+++ b/etc-nginx-session_ticket_keys.mount
@@ -1,0 +1,12 @@
+[Unit]
+Description=ramfs for nginx session ticket keys
+
+[Mount]
+What=ramfs
+Where=/etc/nginx/session_ticket_keys
+Type=ramfs
+Options=mode=0700
+DirectoryMode=0700
+
+[Install]
+WantedBy=multi-user.target

--- a/nginx-create-session-ticket-keys
+++ b/nginx-create-session-ticket-keys
@@ -4,10 +4,7 @@ set -o errexit -o nounset -o pipefail
 
 umask 077
 
-mkdir -p /etc/nginx/session-ticket-keys
-mount -t ramfs -o mode=700 ramfs /etc/nginx/session-ticket-keys
-
-cd /etc/nginx/session-ticket-keys
+cd /etc/nginx/session_ticket_keys
 
 openssl rand -out 1.key 80
 openssl rand -out 2.key 80

--- a/nginx-create-session-ticket-keys.service
+++ b/nginx-create-session-ticket-keys.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Create nginx TLS session ticket keys
 Before=nginx.service
+After=etc-nginx-session_ticket_keys.mount
 
 [Service]
 Type=oneshot
@@ -8,5 +9,46 @@ User=root
 Group=root
 ExecStart=/usr/local/bin/nginx-create-session-ticket-keys
 
-[Install]
-WantedBy=multi-user.target
+PrivateDevices=true
+PrivateIPC=true
+PrivateNetwork=true
+PrivateTmp=true
+PrivateUsers=true
+
+# limit privs
+CapabilityBoundingSet=
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+RemoveIPC=true
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+
+IPAddressDeny=any
+
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=yes
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=invisible
+ProcSubset=pid
+
+DevicePolicy=strict
+DeviceAllow=/dev/random r
+DeviceAllow=/dev/urandom r
+DeviceAllow=/dev/stdin r
+
+ProtectClock=true
+
+# filesystem restrictions
+ProtectSystem=strict
+ReadWritePaths=/etc/nginx/session_ticket_keys
+UMask=0077
+
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@clock @debug @module @mount @reboot @swap @resources @cpu-emulation @obsolete @raw-io @obsolete @keyring @privileged

--- a/nginx-rotate-session-ticket-keys
+++ b/nginx-rotate-session-ticket-keys
@@ -4,7 +4,7 @@ set -o errexit -o nounset -o pipefail
 
 umask 077
 
-cd /etc/nginx/session-ticket-keys
+cd /etc/nginx/session_ticket_keys
 
 rsync -It 2.key 1.key
 rsync -It 3.key 2.key
@@ -12,4 +12,3 @@ rsync -It 4.key 3.key
 openssl rand -out new.key 80
 rsync -It new.key 4.key
 rm new.key
-nginx -s reload

--- a/nginx-rotate-session-ticket-keys.service
+++ b/nginx-rotate-session-ticket-keys.service
@@ -7,3 +7,51 @@ Type=oneshot
 User=root
 Group=root
 ExecStart=/usr/local/bin/nginx-rotate-session-ticket-keys
+ExecStartPost=systemctl reload nginx.service
+
+PrivateDevices=true
+PrivateIPC=true
+PrivateNetwork=true
+PrivateTmp=true
+PrivateUsers=true
+
+# limit privs
+CapabilityBoundingSet=
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+RemoveIPC=true
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+
+# required to run systemctl in ExecStartPost
+RestrictAddressFamilies=AF_UNIX
+
+IPAddressDeny=any
+
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=yes
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=invisible
+ProcSubset=pid
+
+IPAddressDeny=any
+
+DevicePolicy=strict
+DeviceAllow=/dev/random r
+DeviceAllow=/dev/urandom r
+DeviceAllow=/dev/stdin r
+
+# filesystem restrictions
+ProtectSystem=strict
+ReadWritePaths=/etc/nginx/session_ticket_keys
+UMask=0077
+
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@clock @debug @module @mount @reboot @swap @resources @cpu-emulation @obsolete @raw-io @obsolete @keyring @privileged


### PR DESCRIPTION
Before, the scripts ran unconfined in order to mount a ramfs. By
delegating ramfs creation to systemd, the scripts only need to handle
key creation and rotation; this allows them to run with extreme
confinement.

systemd-analyze(1) now describes their overall exposure levels as
"0.5 SAFE"

Additionally: this also enables better SELinux integration since SELinux
locks down systemd mounts in distros like Fedora.

BREAKING CHANGE: the hyphens in the session ticket key directory were
changed to underscores, since systemd-mount(1) escapes slashes with
hyphens.